### PR TITLE
Modernizing php examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ out/
 node_modules
 /javascript/package-lock.json
 /javascript/src/starface-rest-api/package-lock.json
+/php/vendor/

--- a/php/examples/users.php
+++ b/php/examples/users.php
@@ -20,9 +20,9 @@ const PBX_API_PASS = "foobar";  // login password
 /**
  * @param array $installedUsers
  *
- * @return int|mixed
+ * @return int
  */
-function getNextFreeLoginId(array $installedUsers)
+function getNextFreeLoginId(array $installedUsers): int
 {
     $loginId = 1000;
     foreach ($installedUsers as $user) {
@@ -30,48 +30,42 @@ function getNextFreeLoginId(array $installedUsers)
             $loginId = intval($user["login"]);
         }
     }
-    
+
     return ++$loginId;
 }
 
 try {
-    
     // replaces login example:
     $client = new RestClientApiPbx(PBX_API_URL, PBX_API_USER, PBX_API_PASS);
     if (!$client->issetAuthToken()) {
         throw new Exception("Retrieving authToken on login failed");
     }
-    
+
     // retrieve list of installed users:
     $installedUsers = $client->getUsers();
-    
+
     // create new STARFACE user:
     $newUser = array(
-        'login'            => getNextFreeLoginId($installedUsers),
-        'email'            => "max_mustermann@nomail.de",
-        'password'         => "unsafePassword", // TODO: implement pwd generator
-        'familyName'       => "Mustermann",
-        'firstName'        => "Max",
-        'namespace'        => 'STARFACE Examples',
-        'language'         => "de",
+        'login' => getNextFreeLoginId($installedUsers),
+        'email' => "max_mustermann@nomail.de",
+        'password' => "unsafePassword", // TODO: implement pwd generator
+        'familyName' => "Mustermann",
+        'firstName' => "Max",
+        'namespace' => 'STARFACE Examples',
+        'language' => "de",
         'missedCallReport' => false,
-        'faxCoverPage'     => false,
-        'faxEmailJournal'  => false,
+        'faxCoverPage' => false,
+        'faxEmailJournal' => false,
     );
     $client->post("/users", $newUser);
     if ($client->getLastRequestsHttpStatus() != 201) {
         throw new Exception("Creating user failed");
     }
     echo "User {$newUser["familyName"]} with LoginId {$newUser["login"]} successfully created";
-    
 } catch (Exception $e) {
-    
     echo "{$e->getMessage()}  (HTTP {$client->getLastRequestsHttpStatus()})";
-    
 } finally {
-    
     $client->logout();
     $client->closeConnection();
     unset($client);
-    
 }


### PR DESCRIPTION
Effectively I just quickly fixed some php 7.0 code style warnings my IDE threw at me after looking at the example files.
The code autoformat I did afterwards should have employed PSR-12 rules.


